### PR TITLE
Use the 'magick convert' command, not 'convert'

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ reanimate checks:
   Has blender:                       2.82
   Has rsvg-convert:                  2.44.10
   Has inkscape:                      0.92.4
-  Has convert:                       6.9.10-14
+  Has imagemagick:                   6.9.10-14
   Has LaTeX:                         /usr/bin/latex
   Has LaTeX package 'babel':         OK
   Has LaTeX package 'preview':       OK

--- a/reanimate.cabal
+++ b/reanimate.cabal
@@ -105,6 +105,7 @@ library
                       Reanimate.Driver
                       Reanimate.Driver.Check
                       Reanimate.Driver.CLI
+                      Reanimate.Driver.Magick
                       Reanimate.Driver.Server
                       Reanimate.Driver.Compile
                       Paths_reanimate

--- a/src/Reanimate/Driver/CLI.hs
+++ b/src/Reanimate/Driver/CLI.hs
@@ -48,19 +48,19 @@ data Preset = Youtube | ExampleGif | Quick | MediumQ | HighQ | LowFPS
 readRaster :: String -> Maybe Raster
 readRaster raster =
   case map toLower raster of
-    "none"     -> Just RasterNone
-    "auto"     -> Just RasterAuto
-    "inkscape" -> Just RasterInkscape
-    "rsvg"     -> Just RasterRSvg
-    "convert"  -> Just RasterConvert
-    _          -> Nothing
+    "none"          -> Just RasterNone
+    "auto"          -> Just RasterAuto
+    "inkscape"      -> Just RasterInkscape
+    "rsvg"          -> Just RasterRSvg
+    "imagemagick"   -> Just RasterMagick
+    _               -> Nothing
 
 showRaster :: Raster -> String
 showRaster RasterNone     = "none"
 showRaster RasterAuto     = "auto"
 showRaster RasterInkscape = "inkscape"
 showRaster RasterRSvg     = "rsvg"
-showRaster RasterConvert  = "convert"
+showRaster RasterMagick   = "imagemagick"
 
 readFormat :: String -> Maybe Format
 readFormat fmt =
@@ -185,7 +185,7 @@ renderCommand = info parse
           (long "raster" <> showDefaultWith showRaster
           <> metavar "RASTER"
           <> value RasterNone
-          <> help "Raster engine: none, auto, inkscape, rsvg, convert")
+          <> help "Raster engine: none, auto, inkscape, rsvg, imagemagick")
 
 opts :: ParserInfo Options
 opts = info (options <**> helper )

--- a/src/Reanimate/Driver/Check.hs
+++ b/src/Reanimate/Driver/Check.hs
@@ -3,7 +3,7 @@ module Reanimate.Driver.Check
   ( checkEnvironment
   , hasRSvg
   , hasInkscape
-  , hasConvert
+  , hasMagick
   ) where
 
 import           Control.Exception            (SomeException, handle)
@@ -11,6 +11,7 @@ import           Control.Monad
 import           Data.Maybe
 import           Data.Version
 import           Reanimate.Misc               (runCmd_)
+import           Reanimate.Driver.Magick      (magickCmd)
 import           System.Console.ANSI.Codes
 import           System.Directory             (findExecutable)
 import           System.IO
@@ -30,7 +31,7 @@ checkEnvironment = do
     runCheck "Has blender" hasBlender
     runCheck "Has rsvg-convert" hasRSvg
     runCheck "Has inkscape" hasInkscape
-    runCheck "Has convert" hasConvert
+    runCheck "Has imagemagick" hasMagick
     runCheck "Has LaTeX" hasLaTeX
     runCheck ("Has LaTeX package '"++ "babel" ++ "'") $ hasTeXPackage "latex"
       "[english]{babel}"
@@ -107,8 +108,8 @@ hasInkscape = checkMinVersion minVersion <$> inkscapeVersion
   where
     minVersion = Version [0,92] []
 
-hasConvert :: IO (Either String String)
-hasConvert = checkMinVersion minVersion <$> convertVersion
+hasMagick :: IO (Either String String)
+hasMagick = checkMinVersion minVersion <$> magickVersion
   where
     minVersion = Version [6,0,0] []
 
@@ -136,8 +137,8 @@ inkscapeVersion = extractVersion "inkscape" ["--version"] $ \line ->
       ["Inkscape", vs] -> vs
       _                -> ""
 
-convertVersion :: IO (Maybe Version)
-convertVersion = extractVersion "convert" ["-version"] $ \line ->
+magickVersion :: IO (Maybe Version)
+magickVersion = extractVersion magickCmd ["-version"] $ \line ->
     case take 3 $ words line of
       ["Version:", "ImageMagick", vs] -> vs
       _                               -> ""

--- a/src/Reanimate/Driver/Magick.hs
+++ b/src/Reanimate/Driver/Magick.hs
@@ -1,0 +1,18 @@
+module Reanimate.Driver.Magick
+  ( magickCmd
+  ) where
+
+import System.IO.Unsafe (unsafePerformIO)
+import System.Directory (findExecutable)
+
+-- |The name of the ImageMagick command. On Unix-like operating systems, the
+-- command 'convert' does not conflict with the name of other commands. On
+-- Windows, ImageMagick version 7 is readily available, the command 'magick'
+-- should be present, and is preferred over 'convert'. If it is not present,
+-- 'convert' is assumed to be the relevant command.
+magickCmd :: String
+-- The use of 'unsafeperformIO' is justified on the basis that if 'magick' is
+-- found once, it will always be present.
+magickCmd = unsafePerformIO $ do
+  mPath <- findExecutable "magick"
+  pure $ maybe "convert" (const "magick") mPath

--- a/src/Reanimate/Parameters.hs
+++ b/src/Reanimate/Parameters.hs
@@ -29,7 +29,7 @@ data Raster
   | RasterAuto
   | RasterInkscape
   | RasterRSvg
-  | RasterConvert
+  | RasterMagick
   deriving (Show, Eq)
 
 {-# NOINLINE pRasterRef #-}

--- a/src/Reanimate/Raster.hs
+++ b/src/Reanimate/Raster.hs
@@ -33,6 +33,7 @@ import           Graphics.SvgTree                         ( Number(..)
 import qualified Graphics.SvgTree              as Svg
 import           Reanimate.Animation
 import           Reanimate.Cache
+import           Reanimate.Driver.Magick
 import           Reanimate.Misc
 import           Reanimate.Render
 import           Reanimate.Parameters
@@ -248,8 +249,8 @@ vectorize_ args path             = unsafePerformIO $ do
       hClose svgH
       hClose bmpH
       potrace <- requireExecutable "potrace"
-      convert <- requireExecutable "convert"
-      runCmd convert [path, "-flatten", tmpBmpPath]
+      magick <- requireExecutable magickCmd
+      runCmd magick [path, "-flatten", tmpBmpPath]
       runCmd potrace (args ++ ["--svg", "--output", tmpSvgPath, tmpBmpPath])
       renameOrCopyFile tmpSvgPath svgPath
   svg_data <- B.readFile svgPath

--- a/src/Reanimate/Render.hs
+++ b/src/Reanimate/Render.hs
@@ -23,6 +23,7 @@ import           Graphics.SvgTree       (Number (..))
 import           Numeric
 import           Reanimate.Animation
 import           Reanimate.Driver.Check
+import           Reanimate.Driver.Magick
 import           Reanimate.Misc
 import           Reanimate.Parameters
 import           System.Console.ANSI.Codes
@@ -298,14 +299,14 @@ requireRaster raster = do
 
 selectRaster :: Raster -> IO Raster
 selectRaster RasterAuto = do
-  rsvg <- hasRSvg
-  ink  <- hasInkscape
-  conv <- hasConvert
+  rsvg   <- hasRSvg
+  ink    <- hasInkscape
+  magick <- hasMagick
   if
-    | isRight rsvg -> pure RasterRSvg
-    | isRight ink  -> pure RasterInkscape
-    | isRight conv -> pure RasterConvert
-    | otherwise    -> pure RasterNone
+    | isRight rsvg   -> pure RasterRSvg
+    | isRight ink    -> pure RasterInkscape
+    | isRight magick -> pure RasterMagick
+    | otherwise      -> pure RasterNone
 selectRaster r = pure r
 
 applyRaster :: Raster -> FilePath -> IO ()
@@ -320,8 +321,8 @@ applyRaster RasterInkscape path = runCmd
 applyRaster RasterRSvg path = runCmd
   "rsvg-convert"
   [path, "--unlimited", "--output", replaceExtension path "png"]
-applyRaster RasterConvert path =
-  runCmd "convert" [path, replaceExtension path "png"]
+applyRaster RasterMagick path =
+  runCmd magickCmd [path, replaceExtension path "png"]
 
 concurrentForM_ :: [a] -> (a -> IO ()) -> IO ()
 concurrentForM_ lst action = do


### PR DESCRIPTION
On Windows, the name of ImageMagick's `convert` utility clashes with Microsoft's `C:\Windows\System32\convert.exe` utility. Using `magick convert` avoids the conflict.

For consistency, references to 'convert' are changed to 'magick', throughout.

I have done some testing of these proposed changes on Windows 10 version 2004 and WSL 2 with Ubuntu 20.04. The testing is limited because I have other problems with `reanimate`, but I think those problems are to do with FFmpeg and not the ImageMagick part.