### PR TITLE
LaTeX: force UTF-8 output for TeX files

### DIFF
--- a/src/Reanimate/LaTeX.hs
+++ b/src/Reanimate/LaTeX.hs
@@ -15,7 +15,7 @@ where
 import qualified Data.ByteString               as B
 import           Data.Text                                ( Text )
 import qualified Data.Text                     as T
-import qualified Data.Text.IO                  as T
+import qualified Data.Text.Encoding            as T
 import           Graphics.SvgTree                         ( Tree(..)
                                                           , parseSvgFile
                                                           )
@@ -109,7 +109,7 @@ latexToSVG dviExt latexExec latexArgs tex = do
     withTempFile "svg" $ \svg_file -> do
       let dvi_file =
             tmp_dir </> replaceExtension (takeFileName tex_file) dviExt
-      T.writeFile tex_file tex
+      B.writeFile tex_file (T.encodeUtf8 tex)
       runCmd
         latexBin
         (  latexArgs


### PR DESCRIPTION
XeLaTeX requires UTF-8 encoded input, but [`writeFile` from `Data.Text.IO` uses the system locale (starting from GHC 6.12)](https://hackage.haskell.org/package/text-1.2.4.0/docs/Data-Text-IO.html#g:2). On my machine (with codepage 936 as the default), I see unexpected behaviors for `ctex`. Here I changed functions in `Reanimate.LaTeX` to force UTF-8 encoding for output. Before this change, it would work correctly if I run `chcp 65001` to manually switch my codepage to UTF-8.

See following example (modified from `doc_ctex.hs`).

```haskell
#!/usr/bin/env stack
-- stack runghc --package reanimate
{-# LANGUAGE OverloadedStrings #-}
module Main (main) where

import           Reanimate
import           Reanimate.Builtin.Documentation

main :: IO ()
main = reanimate $ docEnv $ animate $ const $
  withStrokeWidth 0 . withFillOpacity 1 . scale 4 . center $
  ctex "test中文test"
```

| Use system locale (936) | Force UTF-8 encoding |
|-|-|
| ![writeFile](https://user-images.githubusercontent.com/17098235/87875299-eccfad00-ca02-11ea-9484-50d7ed57b287.gif) | ![encodeUtf8](https://user-images.githubusercontent.com/17098235/87875304-f6f1ab80-ca02-11ea-9d40-c8b6da74e1b6.gif) |
