### PR TITLE
Improve caching consistency.

### DIFF
--- a/src/Reanimate/Povray.hs
+++ b/src/Reanimate/Povray.hs
@@ -10,20 +10,19 @@ module Reanimate.Povray
   , povrayExtreme'
   ) where
 
-import           Codec.Picture.Png
-import qualified Data.ByteString            as B
+import           Data.Hashable
 import           Data.Text                  (Text)
 import qualified Data.Text                  as T
 import qualified Data.Text.IO               as T
 import           Graphics.SvgTree           (Tree (..))
 import           Reanimate.Cache
+import           Reanimate.Constants
 import           Reanimate.Misc
-import           Reanimate.Raster
 import           Reanimate.Parameters
+import           Reanimate.Raster
 import           Reanimate.Svg.Constructors
 import           System.FilePath            (replaceExtension, (<.>))
 import           System.IO.Unsafe           (unsafePerformIO)
-import           Data.Hashable
 
 povrayRaw :: [String] -> Text -> Tree
 povrayRaw args script =
@@ -59,13 +58,8 @@ povrayExtreme' args = povrayRaw' (["+H2160","+W3840", "+A"] ++ args)
 
 mkPovrayImage :: [String] -> Text -> IO Tree
 mkPovrayImage _ script | pNoExternals = pure $ mkText script
-mkPovrayImage args script = do
-    out <- mkPovrayImage' args script
-    -- return $ center $ scaleToSize 16 9 $ embedImageFile out
-    png <- B.readFile out
-    case decodePng png of
-      Left{}    -> error "bad image"
-      Right img -> return $ center $ scaleToSize 16 9 $ embedDynamicImage img
+mkPovrayImage args script =
+  mkImage screenWidth screenHeight <$> mkPovrayImage' args script
 
 mkPovrayImage' :: [String] -> Text -> IO FilePath
 mkPovrayImage' _ _ | pNoExternals = pure "/povray/has/been/disabled"
@@ -75,5 +69,5 @@ mkPovrayImage' args script = cacheFile template $ \target -> do
     T.writeFile pov_file script
     runCmd exec (args ++ ["-D","+UA", pov_file, "+o"++target])
   where
-    template = show (hash key) <.> "png"
+    template = encodeInt (hash key) <.> "png"
     key = T.concat (script:map T.pack args)

--- a/src/Reanimate/Raster.hs
+++ b/src/Reanimate/Raster.hs
@@ -242,7 +242,7 @@ vectorize_ _ path | pNoExternals = mkText $ T.pack path
 vectorize_ args path             = unsafePerformIO $ do
   root <- getXdgDirectory XdgCache "reanimate"
   createDirectoryIfMissing True root
-  let svgPath = root </> show key <.> "svg"
+  let svgPath = root </> encodeInt key <.> "svg"
   hit <- doesFileExist svgPath
   unless hit $ withSystemTempFile "file.svg" $ \tmpSvgPath svgH ->
     withSystemTempFile "file.bmp" $ \tmpBmpPath bmpH -> do
@@ -289,7 +289,7 @@ svgAsPngFile' width height svg =
     engine <- requireRaster pRaster
     applyRaster engine svgPath
  where
-  template = show (hash rendered) <.> "png"
+  template = encodeInt (hash rendered) <.> "png"
   rendered = renderSvg (Just $ Px $ fromIntegral width)
                        (Just $ Px $ fromIntegral height)
                        svg


### PR DESCRIPTION
 * Improve naming scheme from large numbers to base64 encoded numbers.
 * Don't inline blender/povray images if it can be avoided: This lowers the render time of `tut_glue_blender` from 10.8s to 4.5s with a hot cache. With cold cache:  1m29 to 1m4s.