### PR TITLE
fix LaTeX: headers and postscripts got swapped

### DIFF
--- a/src/Reanimate/LaTeX.hs
+++ b/src/Reanimate/LaTeX.hs
@@ -69,7 +69,7 @@ data TexConfig = TexConfig
 -- | Render TeX script using a given configuration.
 latexCfg :: TexConfig -> T.Text -> SVG
 latexCfg (TexConfig engine headers postscript) =
-  gen headers postscript
+  gen postscript headers
   where
     gen =
       case engine of
@@ -101,9 +101,9 @@ someTexWithHeaders ::
   [T.Text] ->
   T.Text ->
   Tree
-someTexWithHeaders _engine _exec _dvi _args _headers _postscript tex
+someTexWithHeaders _engine _exec _dvi _args _postscript _headers tex
   | pNoExternals = mkText tex
-someTexWithHeaders engine exec dvi args headers postscript tex =
+someTexWithHeaders engine exec dvi args postscript headers tex =
   (unsafePerformIO . (cacheMem . cacheDiskSvg) (latexToSVG engine dvi exec args))
     script
   where


### PR DESCRIPTION
Sorry, but my last PR on LaTeX did not really fix functions `*texWithHeaders`/`ctex` (though functions `latex`/`xelatex` seem to be fixed).

The parameters `postscript` and `headers` were swapped (mistaken for each other), so the `\usepackage` directions did not appear in the preamble as expected (instead, it appeared between `\begin{document}` and `\end{document}`). After this fix, I tested on these functions, and as far as I can tell, they seem to work correctly this time.

P.S. It seems really hard to correctly maintain a bunch of `String`/`Text`/`[String]`/`[Text]` parameters mixed together in one function (especially when `OverloadedStrings` is enabled). That said, though, I did not come up with a better solution for this situation.