### PR TITLE
Create flag for toggling hgeometry dependency.

### DIFF
--- a/reanimate.cabal
+++ b/reanimate.cabal
@@ -37,6 +37,13 @@ Source-Repository head
     Type:      git
     Location:  git://github.com/lemmih/reanimate.git
 
+flag no-hgeometry
+  description:
+    Disable all features that depend on hgeometry. Should only
+    be used when developing new hgeometry algorithms.
+  default: False
+  manual: True
+
 library
   hs-source-dirs:     src
   if os(windows)
@@ -105,6 +112,12 @@ library
                       Reanimate.Scene.Object
                       Detach
   autogen-modules:    Paths_reanimate
+  if flag(no-hgeometry)
+    ghc-options: -DNO_HGEOMETRY
+  else
+    build-depends:
+      hgeometry               >=0.11.0.0,
+      hgeometry-combinatorial >=0.11.0.0
   build-depends:
     base                 >=4.10 && <5,
     JuicyPixels          >=3.3.3,
@@ -126,8 +139,6 @@ library
     fsnotify             >=0.3.0.1,
     geojson              >=3.0.4,
     hashable             >=1.3.0.0,
-    hgeometry            >=0.11.0.0,
-    hgeometry-combinatorial >=0.11.0.0,
     lens                 >=4.16.1,
     linear               >=1.20.8,
     matrix               >=0.3.6.1,

--- a/src/Reanimate/Math/Triangulate.hs
+++ b/src/Reanimate/Math/Triangulate.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_HADDOCK hide #-}
 module Reanimate.Math.Triangulate
   ( Triangulation
@@ -10,6 +11,32 @@ module Reanimate.Math.Triangulate
   , triangulate
   )
 where
+
+#if NO_HGEOMETRY
+
+import qualified Data.Vector                                          as V
+import           Control.Monad.ST
+import           Reanimate.Math.Common
+
+type Triangulation = V.Vector [Int]
+
+edgesToTriangulation :: Int -> [(Int, Int)] -> Triangulation
+edgesToTriangulation = error "no hgeometry"
+
+edgesToTriangulationM :: Int -> [(Int, Int)] -> ST s (V.MVector s [Int])
+edgesToTriangulationM = error "no hgeometry"
+
+trianglesToTriangulation :: Int -> V.Vector (Int, Int, Int) -> Triangulation
+trianglesToTriangulation = error "no hgeometry"
+
+trianglesToTriangulationM
+  :: Int -> V.Vector (Int, Int, Int) -> ST s (V.MVector s [Int])
+trianglesToTriangulationM = error "no hgeometry"
+
+triangulate :: forall a. (Fractional a, Ord a) => Ring a -> Triangulation
+triangulate = error "no hgeometry"
+
+#else
 
 import           Algorithms.Geometry.PolygonTriangulation.Triangulate (triangulate')
 import           Algorithms.Geometry.PolygonTriangulation.Types
@@ -83,3 +110,5 @@ triangulate r = edgesToTriangulation (ringSize r) ds
       [ Point2 x y :+ n
       | (n,V2 x y) <- zip [0..] (V.toList (ringUnpack r)) ]
     -- ringUnpack
+
+#endif


### PR DESCRIPTION
Disabling the hgeometry dependency removes some advanced features:
 - Morphing.
 - Triangulation.
 - Polygon math.

This flag is primarily useful when working on HGeometry.