### PR TITLE
Fillcolor

### DIFF
--- a/examples/doc_fillColor.hs
+++ b/examples/doc_fillColor.hs
@@ -1,0 +1,23 @@
+#!/usr/bin/env stack
+-- stack runghc --package reanimate
+{-# LANGUAGE OverloadedStrings #-}
+module Main(main) where
+
+import Codec.Picture
+import Control.Lens
+import Reanimate
+import Reanimate.Scene
+import Reanimate.Builtin.Documentation
+
+testSVG :: SVG
+testSVG = withStrokeWidth 0
+  $ withFillOpacity 1
+  $ latex "(1,2)"
+
+main :: IO ()
+main = reanimate $ docEnv $ scene $ do
+  test <- oNew testSVG
+  oModifyS test $ do
+    oStrokeColor .= (255 :: Pixel8, 0 :: Pixel8, 0 :: Pixel8)
+    oFillColor .= (255 :: Pixel8, 0 :: Pixel8, 0 :: Pixel8)
+  oShowWith test oDraw

--- a/src/Reanimate/Scene.hs
+++ b/src/Reanimate/Scene.hs
@@ -83,6 +83,7 @@ module Reanimate.Scene
     oBBMinY,
     oBBWidth,
     oBBHeight,
+    oFillColor,
     oOpacity,
     oShown,
     oZIndex,

--- a/src/Reanimate/Scene.hs
+++ b/src/Reanimate/Scene.hs
@@ -84,6 +84,7 @@ module Reanimate.Scene
     oBBWidth,
     oBBHeight,
     oFillColor,
+    oStrokeColor,
     oOpacity,
     oShown,
     oZIndex,

--- a/src/Reanimate/Scene/Object.hs
+++ b/src/Reanimate/Scene/Object.hs
@@ -51,6 +51,7 @@ data ObjectData a = ObjectData
     _oMargin      :: (Double, Double, Double, Double),
     _oBB          :: (Double, Double, Double, Double),
     _oFillColor   :: (Pixel8, Pixel8, Pixel8),
+    _oStrokeColor :: (Pixel8, Pixel8, Pixel8),
     _oOpacity     :: Double,
     _oShown       :: Bool,
     _oZIndex      :: Int,
@@ -98,6 +99,10 @@ oBB = to _oBB
 -- | Object fill color. Default: (0, 0, 0) (black).
 oFillColor :: Lens' (ObjectData a) (Pixel8, Pixel8, Pixel8)
 oFillColor = lens _oFillColor $ \obj val -> obj {_oFillColor = val}
+
+-- | Object stroke color. Default: (0, 0, 0) (black).
+oStrokeColor :: Lens' (ObjectData a) (Pixel8, Pixel8, Pixel8)
+oStrokeColor = lens _oFillColor $ \obj val -> obj {_oStrokeColor = val}
 
 -- | Object opacity. Default: 1
 oOpacity :: Lens' (ObjectData a) Double
@@ -303,6 +308,7 @@ newObject val = do
           _oMargin = (0.5, 0.5, 0.5, 0.5),
           _oBB = boundingBox svg,
           _oFillColor = (0, 0, 0),
+          _oStrokeColor = (0, 0, 0),
           _oOpacity = 1,
           _oShown = False,
           _oZIndex = 1,
@@ -317,6 +323,7 @@ newObject val = do
         then
           uncurryV2 translate _oTranslate $
             oScaleApply obj $
+              withStrokeColorPixel (uncurry3 opaquePixel _oStrokeColor) $
               withFillColorPixel (uncurry3 opaquePixel _oFillColor) $
               	withGroupOpacity _oOpacity $
                   mkGroup [_oContext _oSVG]


### PR DESCRIPTION
Not sure if you want `oFillColor` and `oStrokeColor` in the project, but here is a pull request for them if you want otherwise feel free to close. Fairly inexperienced at Haskell, so I could have made some mistakes.

Includes:

- An `oFillColor` and `oStrokeColor` method.
- Example that draws a read `(1,2)` to the screen.