### PR TITLE
Update for updated inkscape command line options

### DIFF
--- a/src/Reanimate/Driver/Check.hs
+++ b/src/Reanimate/Driver/Check.hs
@@ -120,7 +120,7 @@ hasRSvg = checkMinVersion minVersion <$> rsvgVersion
 hasInkscape :: IO (Either String String)
 hasInkscape = checkMinVersion minVersion <$> inkscapeVersion
   where
-    minVersion = Version [0,92] []
+    minVersion = Version [1,0] []
 
 hasMagick :: IO (Either String String)
 hasMagick = checkMinVersion minVersion <$> magickVersion

--- a/src/Reanimate/Render.hs
+++ b/src/Reanimate/Render.hs
@@ -413,9 +413,8 @@ applyRaster RasterNone     _    = return ()
 applyRaster RasterAuto     _    = return ()
 applyRaster RasterInkscape path = runCmd
   "inkscape"
-  [ "--without-gui"
-  , "--file=" ++ path
-  , "--export-png=" ++ replaceExtension path "png"
+  ["--export-type=png"
+  , path
   ]
 applyRaster RasterRSvg path = runCmd
   "rsvg-convert"


### PR DESCRIPTION
The current version of inkscape is 1.1.1. Its command line changed at some point and no longer includes `--without-gui`, `--file` or `--export-png`. See https://inkscape.org/doc/inkscape-man.html.

What was once:
~~~
inkscape --without-gui --file=test.svg --export-png=test.png
~~~

is now:
~~~
inkscape --export-type=png test.svg
~~~