### PR TITLE
Refactor `Reanimate.Povray` and OS-specifc `POVRay`

### DIFF
--- a/unix/POVRay.hs
+++ b/unix/POVRay.hs
@@ -1,27 +1,16 @@
 module POVRay
   ( povrayApp
-  , mkPovrayImage'
+  , runPOVRay
   ) where
 
-import           Data.Hashable        (Hashable (hash))
-import           Data.Text            (Text)
-import qualified Data.Text            as T (concat, pack)
-import qualified Data.Text.IO         as T (writeFile)
-import           Reanimate.Cache      (cacheFile, encodeInt)
-import           Reanimate.Misc       (requireExecutable, runCmd)
-import           Reanimate.Parameters (pNoExternals)
-import           System.FilePath      (replaceExtension, (<.>))
+import Reanimate.Misc (requireExecutable, runCmd)
 
+-- | Name of the POV-Ray executable
 povrayApp :: String
 povrayApp = "povray"
 
-mkPovrayImage' :: [String] -> Text -> IO FilePath
-mkPovrayImage' _ _ | pNoExternals = pure "/povray/has/been/disabled"
-mkPovrayImage' args script = cacheFile template $ \target -> do
+-- | Run the POV-Ray executable with arguments
+runPOVRay :: [String] -> IO ()
+runPOVRay args = do
   exec <- requireExecutable povrayApp
-  let pov_file = replaceExtension target "pov"
-  T.writeFile pov_file script
-  runCmd exec (args ++ ["-D", "+UA", "+I" ++ pov_file, "+o" ++ target])
- where
-  template = encodeInt (hash key) <.> "png"
-  key = T.concat (script:map T.pack args)
+  runCmd exec args


### PR DESCRIPTION
Further to pull request #225, I realised subsequently that the common code in the two `POVRay.mkPovrayImage'` functions could be returned to module `Reanimate.Povray`, and all that needed to be Windows- or Unix-like-specific was a `runPOVRay` function.

This pull request does that refactoring.