### PR TITLE
Update POV-Ray examples to avoid POV-Ray warnings

### DIFF
--- a/examples/tut_glue_povray.hs
+++ b/examples/tut_glue_povray.hs
@@ -53,6 +53,8 @@ script png transZ rotX rotZ =
       transZ_ = T.pack $ show transZ
       rotZ_ = T.pack $ show rotZ
   in [text|
+#version 3.7;
+//Files with predefined colors and textures
 #include "colors.inc"
 
 //Place the camera
@@ -64,6 +66,8 @@ camera {
   right x*16/9
 }
 
+global_settings { assumed_gamma 1.0 }
+
 //Ambient light to "brighten up" darker pictures
 global_settings { ambient_light White*3 }
 
@@ -71,15 +75,15 @@ global_settings { ambient_light White*3 }
 background { color rgbt <0, 0, 0, 1> } // transparent
 
 polygon {
-  4,
-  <0, 0>, <0, 1>, <1, 1>, <1, 0>
+  5,
+  <0, 0>, <0, 1>, <1, 1>, <1, 0>, <0, 0>
   texture {
     pigment{
       image_map{ png "${png_}" }
     }
   }
   translate <-1/2,-1/2>
-  scale <16,9>
+  scale <16,9,1>
   rotate <0,${rotX_},${rotZ_}>
   translate <0,0,${transZ_}>
 }

--- a/examples/tut_glue_povray_ortho.hs
+++ b/examples/tut_glue_povray_ortho.hs
@@ -60,6 +60,7 @@ script png rotX rotY rotZ =
       rotY_ = T.pack $ show rotY
       rotZ_ = T.pack $ show rotZ
   in [text|
+# version 3.7;
 //Files with predefined colors and textures
 #include "colors.inc"
 
@@ -74,6 +75,7 @@ camera {
   right x*16
 }
 
+global_settings { assumed_gamma 1.0 }
 
 //Ambient light to "brighten up" darker pictures
 global_settings { ambient_light White*3 }


### PR DESCRIPTION
This pull request updates the POV scripts in the two POV-Ray examples to avoid the warning messages in POV-Ray 3.7 (released November 2013).

POV-Ray 3.7 requires the `version` directive.

POV-Ray 3.7 considers the `assumed_gamma` keyword to be mandatory.

POV-Ray warns when a `polygon` is not closed.

POV-Ray warns when a scaling component is omitted.