### PR TITLE
Correct and extend `Reanimate.Povray' Haddock documentation

### DIFF
--- a/src/Reanimate/Povray.hs
+++ b/src/Reanimate/Povray.hs
@@ -1,7 +1,25 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-|
-  [Povray](http://povray.org/) is a scriptable raytracer. All povray functions
-  are cached and will reuse images when scripts stay the same.
+  [POV-Ray](http://povray.org/) (the Persistance of Vision Raytracer) is a
+  scriptable raytracer. All POV-Ray functions are cached and will reuse images
+  when scripts stay the same.
+
+  The functions come in two versions, for example 'povray' and 'povray''. The
+  versions without an apostrophe character yield a 'Tree'. The versions with a
+  final apostrophe character yield a 'FilePath' of a PNG file containing the
+  resulting image.
+
+  The functions differ in their use of the POV-Ray @+W@ (width), @+H@ (height)
+  and @+A@ or @-A@ (anti-aliasing) switches, as set out below. Resolutions are
+  \'width x height\'.
+
+  Example of use:
+
+  > povray args script
+
+  where @args@ is a list of other POV-Ray command-line switches (if any), and
+  @script@ is a POV-Ray scene description specified in the POV-Ray /scene/
+  /description language/.
 -}
 module Reanimate.Povray
   ( povray
@@ -31,53 +49,53 @@ povrayRaw' :: [String] -> Text -> FilePath
 povrayRaw' args script =
   unsafePerformIO $ mkPovrayImage' args script
 
--- | Run the povray raytracer with a default resolution of 320x180
+-- | Run the POV-Ray raytracer with a default resolution of 320x180
 --   and antialiasing enabled. The resulting image is scaled to fit
 --   the screen exactly.
 povray :: [String] -> Text -> Tree
-povray args = povrayRaw (["+H180","+W320", "+A"] ++ args)
+povray args = povrayRaw (["+H180", "+W320", "+A"] ++ args)
 
--- | Run the povray raytracer with a default resolution of 320x180
+-- | Run the POV-Ray raytracer with a default resolution of 320x180
 --   and antialiasing enabled. The FilePath points to a PNG file
 --   containing the resulting image.
 povray' :: [String] -> Text -> FilePath
-povray' args = povrayRaw' (["+H180","+W320", "+A"] ++ args)
+povray' args = povrayRaw' (["+H180", "+W320", "+A"] ++ args)
 
--- | Run the povray raytracer with a default resolution of 320x180
+-- | Run the POV-Ray raytracer with a default resolution of 320x180
 --   but without antialiasing. The resulting image is scaled to fit
 --   the screen exactly.
 povrayQuick :: [String] -> Text -> Tree
-povrayQuick args = povrayRaw (["+H180","+W320"] ++ args)
+povrayQuick args = povrayRaw (["+H180", "+W320"] ++ args)
 
--- | Run the povray raytracer with a default resolution of 320x180
+-- | Run the POV-Ray raytracer with a default resolution of 320x180
 --   but without antialiasing. The FilePath points to a PNG file
 --   containing the resulting image.
 povrayQuick' :: [String] -> Text -> FilePath
-povrayQuick' args = povrayRaw' (["+H180","+W320"] ++ args)
+povrayQuick' args = povrayRaw' (["+H180", "+W320"] ++ args)
 
--- | Run the povray raytracer with a default resolution of 1440x2560
---   and antialiasing enabled. The FilePath points to a PNG file
---   containing the resulting image.
+-- | Run the POV-Ray raytracer with a default resolution of 2560x1440
+--   and antialiasing enabled. The resulting image is scaled to fit
+--   the screen exactly.
 povraySlow :: [String] -> Text -> Tree
-povraySlow args = povrayRaw (["+H1440","+W2560", "+A"] ++ args)
+povraySlow args = povrayRaw (["+H1440", "+W2560", "+A"] ++ args)
 
--- | Run the povray raytracer with a default resolution of 1440x2560
+-- | Run the POV-Ray raytracer with a default resolution of 2560x1440
 --   and antialiasing enabled. The FilePath points to a PNG file
 --   containing the resulting image.
 povraySlow' :: [String] -> Text -> FilePath
-povraySlow' args = povrayRaw' (["+H1440","+W2560", "+A"] ++ args)
+povraySlow' args = povrayRaw' (["+H1440", "+W2560", "+A"] ++ args)
 
--- | Run the povray raytracer with a default resolution of 2160x3840
---   and antialiasing enabled. The FilePath points to a PNG file
---   containing the resulting image.
+-- | Run the POV-Ray raytracer with a default resolution of 3840x2160
+--   and antialiasing enabled. The resulting image is scaled to fit
+--   the screen exactly.
 povrayExtreme :: [String] -> Text -> Tree
-povrayExtreme args = povrayRaw (["+H2160","+W3840", "+A"] ++ args)
+povrayExtreme args = povrayRaw (["+H2160", "+W3840", "+A"] ++ args)
 
--- | Run the povray raytracer with a default resolution of 2160x3840
+-- | Run the POV-Ray raytracer with a default resolution of 3840x2160
 --   and antialiasing enabled. The FilePath points to a PNG file
 --   containing the resulting image.
 povrayExtreme' :: [String] -> Text -> FilePath
-povrayExtreme' args = povrayRaw' (["+H2160","+W3840", "+A"] ++ args)
+povrayExtreme' args = povrayRaw' (["+H2160", "+W3840", "+A"] ++ args)
 
 mkPovrayImage :: [String] -> Text -> IO Tree
 mkPovrayImage _ script | pNoExternals = pure $ mkText script


### PR DESCRIPTION
This pull request corrects the Haddock documentation for `Reanimate.Povray` (incorrect narrative for some of the functions yielding `Tree' and inconsistent use of 'width x height' dimensions).

It also extends the introductory Haddock documenation to describe the structure of the functions exported and the use of their arguments, common to all the functions.