### PR TITLE
Suppress false broken link reports

### DIFF
--- a/.github/workflows/site-checks.yml
+++ b/.github/workflows/site-checks.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Check links at reanimate.github.io
       run: checklink --quiet --broken "https://reanimate.github.io/" >> failures.txt
     - name: Check links at reanimate.readthedocs.io
-      run: checklink --quiet --broken "https://reanimate.readthedocs.io/" >> failures.txt
+      run: checklink --quiet --broken "https://reanimate.readthedocs.io/" --suppress-broken 403:https://inkscape.org/ --suppress-broken 403:https://wiki.gnome.org/Projects/LibRsvg >> failures.txt
     # Haddock generates 404 links by default. :(
     #- name: Check links in haddock docs
     #  run: checklink --quiet --broken "https://hackage.haskell.org/package/reanimate/docs/Reanimate.html" >> failures.txt


### PR DESCRIPTION
The link checker (in the site checks workflow) is reporting that the links in documentation to inkscape.org and wiki.gnome.org/Projects/LibRsvg are broken (with code 403 - Forbidden) when they are good links.