### PR TITLE
Fix build for ghc-9.2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,11 @@ Notable changes to the project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and the
 project adheres to the [Haskell Package Versioning
 Policy (PVP)](https://pvp.haskell.org)
+
+## 1.1.7.0 -- 2022-10-15
+
+ * Derive `Eq` for APolygon
+
 ## 1.1.6.0 -- 2022-06-02
 
  * Drop hgeometry dependency.

--- a/reanimate.cabal
+++ b/reanimate.cabal
@@ -3,7 +3,7 @@ cabal-version:       2.0
 --  see http://haskell.org/cabal/users-guide/
 
 name:                reanimate
-version:             1.1.6.0
+version:             1.1.7.0
 -- synopsis:
 -- description:
 license:             PublicDomain
@@ -110,7 +110,7 @@ library
   build-depends:
     base                 >=4.10 && <5,
     JuicyPixels          >=3.3.3,
-    aeson                >=1.3.0.0 && <2,
+    aeson                >=1.3.0.0 && <2.2,
     ansi-terminal        >=0.8.0.4,
     array                >=0.5.2.0,
     attoparsec           >=0.13.2.0,

--- a/src/Reanimate/Math/Polygon.hs
+++ b/src/Reanimate/Math/Polygon.hs
@@ -115,7 +115,7 @@ data APolygon a = Polygon
   , polygonOffset        :: Int
   , polygonTriangulation :: Triangulation
   , polygonSSSP          :: Vector SSSP
-  }
+  } deriving Eq
 type Polygon = APolygon Rational
 type P = V2 Double
 


### PR DESCRIPTION
* A new Eq instance for APolygon because of hashable changes
* Updated aeson bounds
* Bumped the version to 1.1.7 since the Eq instance might cause overlapped instances.