### PR TITLE
Fix compatibility with mtl-2.3 and lts-22

### DIFF
--- a/src/Reanimate/Svg.hs
+++ b/src/Reanimate/Svg.hs
@@ -15,6 +15,7 @@ module Reanimate.Svg
   ) where
 
 import           Control.Lens               ((%~), (&), (.~), (?~), (^.))
+import           Control.Monad              (liftM3, liftM4)
 import           Control.Monad.State
 import           Graphics.SvgTree
 import           Linear.V2                  (V2 (V2))

--- a/src/Reanimate/Svg/LineCommand.hs
+++ b/src/Reanimate/Svg/LineCommand.hs
@@ -16,9 +16,9 @@ module Reanimate.Svg.LineCommand
 where
 
 import           Control.Lens              ((%~), (&), (.~))
+import           Control.Monad             (forM)
 import           Control.Monad.Fix         (MonadFix (mfix))
-import           Control.Monad.State       (MonadState (get, put), State, evalState, forM, gets,
-                                            modify)
+import           Control.Monad.State       (MonadState (get, put), State, evalState, gets, modify)
 import           Data.Functor              (($>))
 import           Data.Maybe                (mapMaybe)
 import qualified Data.Vector.Unboxed       as V

--- a/stack-lts-22.yaml
+++ b/stack-lts-22.yaml
@@ -1,0 +1,8 @@
+resolver: lts-22.3
+
+allow-newer: false
+
+packages:
+- .
+
+extra-deps: []


### PR DESCRIPTION
Some functions are no longer exported from `Control.Monad.State`. Use the export from `Control.Monad` instead. This makes it compile with mtl-2.3 and lts-22.3. I feel the main `stack.yaml` should also be updated, but just to be safe I added a `stack-lts-22.yaml`, instead. The bounds on `reanimate-svg` should also be released to make compilation successful (I believe this is covered by reanimate/reanimate-svg#45, which in turn cherry-picks Twinside/svg-tree#29).